### PR TITLE
White color consistency for blessed items

### DIFF
--- a/blessed/src/030.svg
+++ b/blessed/src/030.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg779"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="advent_alt_source.svg"
+   sodipodi:docname="030.svg"
    inkscape:export-filename="2024-12-06_pre-advent-announce_comparator.png"
    inkscape:export-xdpi="72"
    inkscape:export-ydpi="72"
@@ -27,9 +27,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="0.06304666"
-     inkscape:cx="8176.4839"
-     inkscape:cy="5313.5249"
+     inkscape:zoom="0.50437328"
+     inkscape:cx="849.56919"
+     inkscape:cy="1134.0807"
      inkscape:window-width="2560"
      inkscape:window-height="1403"
      inkscape:window-x="0"
@@ -116,13 +116,13 @@
          class="cls-2"
          d="m -640.69048,-1513.3239 c 0.6517,25.7191 14.7793,62.3265 14.7793,62.3265 l -10.9808,15.1201 c -14.9759,4.9224 -19.6869,-4.1456 -23.4408,-10.018 0,0 -12.2159,-34.6416 -21.8443,-58.995 l -6.1016,-17.3116 z"
          id="path13172"
-         style="fill:#e9e9e9;fill-opacity:1;stroke:#e9e9e9;stroke-width:10.7762px;stroke-miterlimit:10;stroke-opacity:1"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:10.776;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none"
          sodipodi:nodetypes="ccccccc" />
       <path
          class="cls-2"
          d="m -730.04818,-1385.2894 c 6.1745,-23.2365 13.9782,-43.752 25.8827,-65.1324 0,0 15.23,-32.472 23.0609,-57.6181 v 0 c 1.7921,-5.819 7.6869,-9.3406 13.7936,-8.4065 4.8875,0.7874 10.0574,1.5205 15.5911,2.145 2.0093,0.2716 4.0214,0.353 6.0334,0.5702 12.1551,0.335 23.948,0.8281 35.3217,0.9125 5.6869,0.042 11.269,-0.018 16.7392,-0.2506 5.4702,-0.233 14.8268,-1.0643 20.0661,-1.714 1.5043,-0.187 28.7691,-3.6554 29.687,-122.2833 -1.9028,-118.4667 -35.1481,-114.8771 -36.4929,-114.8771 -48.4921,0 -75.721,36.2818 -122.4889,80.1772 -63.1489,59.2694 -102.5176,13.0742 -118.8256,-20.1882 -10.0601,-22.5587 -19.0395,-47.5611 -34.7013,-62.2155 -2.2265,-2.0907 -3.0872,-5.3165 -2.4437,-8.4065 l 1.7921,-8.3333 c 0.2715,-1.0861 -0.4888,-2.0908 -1.6563,-2.2265 -7.4019,-0.4888 -13.5058,2.0908 -18.8957,8.2627 -2.5795,-0.6517 -5.3871,-1.1405 -8.4065,-1.4392 -19.39522,-2.0908 -23.27532,7.7603 -42.09763,7.7603 h -9.1234 c -17.02751,0 -31.25822,8.1134 -38.22023,20.0443 -5.5555,9.5172 -5.7428,19.8732 3.38051,20.8779 -2.81301,10.0249 6.5683,13.9376 27.52211,4.3363 0,0 16.47361,9.4628 39.29822,9.4628 12.33551,0 16.00931,1.9551 20.53562,21.7197 10.9181,48.0607 54.0232,127.0893 141.1673,127.0893 0.9232,1.3033 1.7921,2.5795 2.661,3.7335 14.8009,20.9782 19.3273,47.4875 10.7769,71.5557 -6.8968,19.4685 -15.6617,34.4107 -15.6617,34.4107 0.2715,2.661 0.2715,5.2459 0.2715,7.8309 -0.4248,20.4394 -5.7308,43.6059 -10.7001,57.6018"
          id="path13174"
-         style="fill:#e9e9e9;fill-opacity:1;stroke:#e9e9e9;stroke-width:10.776;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:10.776;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:nodetypes="ccsscccssccsccccccccsscccsccccccc" />
       <path
          class="cls-1"
@@ -130,7 +130,7 @@
          id="path13176"
          style="fill:#005a7d;fill-opacity:1;stroke:none;stroke-width:0px;stroke-opacity:1" />
       <circle
-         style="fill:none;fill-opacity:1;stroke:#e9e9e9;stroke-width:25;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:25;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
          id="circle13178"
          cx="-801.30707"
          cy="-1632.2129"

--- a/blessed/src/031.svg
+++ b/blessed/src/031.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg779"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="advent_alt_source.svg"
+   sodipodi:docname="031.svg"
    inkscape:export-filename="2024-12-06_pre-advent-announce_comparator.png"
    inkscape:export-xdpi="72"
    inkscape:export-ydpi="72"
@@ -27,9 +27,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="0.06304666"
-     inkscape:cx="8176.4839"
-     inkscape:cy="5313.5249"
+     inkscape:zoom="0.50437328"
+     inkscape:cx="1002.2339"
+     inkscape:cy="1371.9997"
      inkscape:window-width="2560"
      inkscape:window-height="1403"
      inkscape:window-x="0"
@@ -113,13 +113,13 @@
        class="cls-2"
        d="m 46.262892,-1734.0088 c 0.6517,25.7191 14.7793,62.3265 14.7793,62.3265 l -10.9808,15.1201 c -14.9759,4.9224 -19.6869,-4.1456 -23.4408,-10.018 0,0 -12.2159,-34.6416 -21.8443,-58.995"
        id="path14364"
-       style="fill:none;fill-opacity:1;stroke:#e9e9e9;stroke-width:10.7762px;stroke-miterlimit:10;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10.7762px;stroke-miterlimit:10;stroke-opacity:1"
        sodipodi:nodetypes="ccccc" />
     <path
        class="cls-2"
        d="m -43.094808,-1607.0348 c 6.1745,-23.2365 13.9782,-43.752 25.8827,-65.1324 0,0 15.23,-32.472 23.0609,-57.6181 v 0 c 1.7921,-5.819 7.6869,-9.3406 13.7936,-8.4065 4.8875,0.7874 10.0574,1.5205 15.5911,2.145 2.0093,0.2716 4.0214,0.353 6.0334,0.5702 12.1551,0.335 23.948,0.8281 35.3217,0.9125 5.6869,0.042 11.269,-0.018 16.7392,-0.2506 5.4702,-0.233 14.826798,-1.0643 20.066098,-1.714 1.5043,-0.187 28.7691,-3.6554 29.687,-122.2833 -1.9028,-118.4667 -35.1481,-114.8771 -36.4929,-114.8771 -48.492098,0 -75.720998,36.2818 -122.488898,80.1772 -63.1489,59.2694 -102.517602,13.0742 -118.825602,-20.1882 -10.0601,-22.5587 -19.0395,-47.5611 -34.7013,-62.2155 -2.2265,-2.0907 -3.0872,-5.3165 -2.4437,-8.4065 l 1.7921,-8.3333 c 0.2715,-1.0861 -0.4888,-2.0908 -1.6563,-2.2265 -7.4019,-0.4888 -13.5058,2.0908 -18.8957,8.2627 -2.5795,-0.6517 -5.3871,-1.1405 -8.4065,-1.4392 -19.39522,-2.0908 -23.27532,7.7603 -42.09763,7.7603 h -9.1234 c -17.02751,0 -31.25822,8.1134 -38.22023,20.0443 -5.5555,9.5172 -5.7428,19.8732 3.38051,20.8779 -2.81301,10.0249 6.5683,13.9376 27.52211,4.3363 0,0 16.47361,9.4628 39.29822,9.4628 12.33551,0 16.00931,1.9551 20.53562,21.7197 10.9181,48.0607 54.0232,127.0893 141.167302,127.0893 0.9232,1.3033 1.7921,2.5795 2.661,3.7335 14.8009,20.9782 19.3273,47.4875 10.7769,71.5557 -6.8968,19.4685 -15.6617,34.4107 -15.6617,34.4107 0.2715,2.661 0.2715,5.2459 0.2715,7.8309 -0.4248,20.4394 -5.7308,43.6059 -10.7001,57.6018"
        id="path14366"
-       style="fill:none;fill-opacity:1;stroke:#e9e9e9;stroke-width:10.776;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:10.776;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
        sodipodi:nodetypes="ccsscccssccsccccccccsscccsccccccc" />
     <path
        class="cls-1"
@@ -127,7 +127,7 @@
        id="path14368"
        style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0px;stroke-opacity:1" />
     <circle
-       style="fill:none;fill-opacity:1;stroke:#e9e9e9;stroke-width:25;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:25;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
        id="circle14370"
        cx="-114.3537"
        cy="-1853.9592"

--- a/blessed/src/032.svg
+++ b/blessed/src/032.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg779"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="advent_alt_source.svg"
+   sodipodi:docname="032.svg"
    inkscape:export-filename="2024-12-06_pre-advent-announce_comparator.png"
    inkscape:export-xdpi="72"
    inkscape:export-ydpi="72"
@@ -27,9 +27,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="0.06304666"
-     inkscape:cx="8176.4839"
-     inkscape:cy="5313.5249"
+     inkscape:zoom="1.4265831"
+     inkscape:cx="995.73592"
+     inkscape:cy="815.93567"
      inkscape:window-width="2560"
      inkscape:window-height="1403"
      inkscape:window-x="0"
@@ -104,7 +104,7 @@
        id="g14388"
        transform="translate(0,-211.66673)">
       <circle
-         style="fill:#e9e9e9;fill-opacity:1;stroke-width:0.122307"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.122307"
          id="circle13158"
          cx="-800.4975"
          cy="-928.90619"
@@ -128,7 +128,7 @@
          class="cls-1"
          d="m -888.00868,-1042.5038 c -0.4888,0.2715 -1.33051,0.353 -2.28091,0.4616 -0.6788,4.1353 -4.0864,7.3367 -8.42,7.3367 -4.3309,0 -7.80371,-3.1986 -8.48801,-7.3367 -0.9504,0 -1.7921,-0.2715 -2.2808,-0.4616 -2.1994,-0.9232 4.2548,-6.1203 10.72261,-6.1203 6.4678,0 12.91931,5.189 10.72271,6.1203 z"
          id="path13164"
-         style="fill:#e9e9e9;fill-opacity:1;stroke:none;stroke-width:0px;stroke-opacity:1" />
+         style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0px;stroke-opacity:1" />
       <circle
          style="fill:none;fill-opacity:1;stroke:#005a7d;stroke-width:25;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
          id="circle13166"
@@ -136,7 +136,7 @@
          cy="-928.42206"
          r="256.42252" />
       <circle
-         style="fill:none;fill-opacity:1;stroke:#e9e9e9;stroke-width:27.2969;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:27.2969;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
          id="circle13168"
          cx="-801.30707"
          cy="-928.42206"

--- a/blessed/src/033.svg
+++ b/blessed/src/033.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg779"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   sodipodi:docname="advent_alt_source.svg"
+   sodipodi:docname="033.svg"
    inkscape:export-filename="2024-12-06_pre-advent-announce_comparator.png"
    inkscape:export-xdpi="72"
    inkscape:export-ydpi="72"
@@ -27,9 +27,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="false"
-     inkscape:zoom="0.06304666"
-     inkscape:cx="8176.4839"
-     inkscape:cy="5313.5249"
+     inkscape:zoom="0.50437328"
+     inkscape:cx="449.07216"
+     inkscape:cy="1052.7917"
      inkscape:window-width="2560"
      inkscape:window-height="1403"
      inkscape:window-x="0"
@@ -107,7 +107,7 @@
        inkscape:export-xdpi="72"
        inkscape:export-ydpi="72">
       <circle
-         style="fill:#e9e9e9;fill-opacity:1;stroke-width:0.122307"
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.122307"
          id="circle12571"
          cx="-112.58117"
          cy="-920.57898"
@@ -125,7 +125,7 @@
          class="cls-2"
          d="m -42.131203,-673.17135 c 6.1745,-23.2365 13.9782,-43.752 25.8827,-65.1324 0,0 15.2300003,-32.472 23.0609003,-57.6181 v 0 c 1.7921,-5.819 7.6868997,-9.3406 13.7935997,-8.4065 4.8875,0.7874 10.0574,1.5205 15.5911,2.145 2.0093,0.2716 4.0214,0.353 6.0334,0.5702 12.1551,0.335 23.948,0.8281 35.3217,0.9125 5.6869,0.042 11.269,-0.018 16.7392,-0.2506 5.4702,-0.233 14.826803,-1.0643 20.066103,-1.714 1.5043,-0.187 28.7691,-3.6554 29.687,-122.2833 -1.9028,-118.46675 -35.1481,-114.87715 -36.4929,-114.87715 -48.492103,0 -75.721003,36.2818 -122.488903,80.17725 -63.1489,59.2694 -102.517597,13.0742 -118.825597,-20.1882 -10.0601,-22.55875 -19.0395,-47.56115 -34.7013,-62.21555 -2.2265,-2.0907 -3.0872,-5.3165 -2.4437,-8.4065 l 1.7921,-8.3333 c 0.2715,-1.0861 -0.4888,-2.0908 -1.6563,-2.2265 -7.4019,-0.4888 -13.5058,2.0908 -18.8957,8.2627 -2.5795,-0.6517 -5.3871,-1.1405 -8.4065,-1.4392 -19.39521,-2.0908 -23.27531,7.7603 -42.09761,7.7603 h -9.1234 c -17.0275,0 -31.2582,8.1134 -38.2202,20.0443 -5.5555,9.5172 -5.7428,19.8732 3.3805,20.8779 -2.813,10.02495 6.5683,13.93765 27.5221,4.3363 0,0 16.4736,9.46285 39.2982,9.46285 12.3355,0 16.0093,1.9551 20.53561,21.7197 10.9181,48.0607 54.0232,127.0893 141.167297,127.0893 0.9232,1.3033 1.7921,2.5795 2.661,3.7335 14.8009,20.9782 19.3273,47.4875 10.7769,71.5557 -6.8968,19.4685 -15.6617,34.4107 -15.6617,34.4107 0.2715,2.661 0.2715,5.2459 0.2715,7.8309 -0.4248,20.4394 -5.7308,43.6059 -10.7001,57.6018"
          id="path12575"
-         style="fill:#e9e9e9;fill-opacity:1;stroke:#005a7d;stroke-width:10.776;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:#ffffff;fill-opacity:1;stroke:#005a7d;stroke-width:10.776;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
          sodipodi:nodetypes="ccsscccssccsccccccccsscccsccccccc" />
       <path
          class="cls-1"
@@ -139,7 +139,7 @@
          cy="-920.09485"
          r="256.42252" />
       <circle
-         style="fill:none;fill-opacity:1;stroke:#e9e9e9;stroke-width:27.2969;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;fill-opacity:1;stroke:#ffffff;stroke-width:27.2969;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
          id="circle12581"
          cx="-113.39074"
          cy="-920.09485"


### PR DESCRIPTION
Do not use light grey anymore, use white.

Overdue color consistency fixes that were detected early. 

This is #6 